### PR TITLE
Implementing Descriptions

### DIFF
--- a/src/editor/nodeDefs/analysis/sentiment.js
+++ b/src/editor/nodeDefs/analysis/sentiment.js
@@ -36,8 +36,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      <p>Returns a numerical value based off of sentiment analysis</p>
-    }
+    renderDescription: () => <p>Returns a numerical value based off of sentiment analysis</p>
   });
 };

--- a/src/editor/nodeDefs/analysis/sentiment.js
+++ b/src/editor/nodeDefs/analysis/sentiment.js
@@ -35,6 +35,9 @@ module.exports = function(RED){
 
         </div>
       )
+    },
+    renderDescription: function () {
+      <p>Returns a numerical value based off of sentiment analysis</p>
     }
   });
 };

--- a/src/editor/nodeDefs/core/catch.js
+++ b/src/editor/nodeDefs/core/catch.js
@@ -280,6 +280,11 @@ module.exports = function(RED){
 
             </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Catch errors thrown by nodes on the same tab.</p>
+      )
     }
   });
 }

--- a/src/editor/nodeDefs/core/comment.js
+++ b/src/editor/nodeDefs/core/comment.js
@@ -78,9 +78,6 @@ module.exports = function(RED){
     renderHelp: function(){
       return (<p>A node you can use to add comments to your flows.</p>);
     },
-    renderDescription: function () {
-      return( <p>A node you can use to add comments to your flows.</p> )
-    }
+    renderDescription: () => <p>A node you can use to add comments to your flows.</p>
   });
-
 };

--- a/src/editor/nodeDefs/core/comment.js
+++ b/src/editor/nodeDefs/core/comment.js
@@ -77,6 +77,9 @@ module.exports = function(RED){
     },
     renderHelp: function(){
       return (<p>A node you can use to add comments to your flows.</p>);
+    },
+    renderDescription: function () {
+      return( <p>A node you can use to add comments to your flows.</p> )
     }
   });
 

--- a/src/editor/nodeDefs/core/debug.js
+++ b/src/editor/nodeDefs/core/debug.js
@@ -344,10 +344,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Display the output of any node.</p>
-      )
-    }
-  });
+    renderDescription: () => <p>Display the output of any node.</p>
+   });
 };

--- a/src/editor/nodeDefs/core/debug.js
+++ b/src/editor/nodeDefs/core/debug.js
@@ -343,6 +343,11 @@ module.exports = function(RED){
         <p>In addition any calls to node.warn or node.error will appear here.</p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Display the output of any node.</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/core/delay.js
+++ b/src/editor/nodeDefs/core/delay.js
@@ -176,6 +176,9 @@ module.exports = function(RED){
                 So each "topic" gets a turn - but the most recent value is always the one sent.</p>
             </div>
           )
+        },
+        renderDescription: function () {
+          <p>Introduces a delay into a flow or rate limits messages.</p>
         }
     });
 

--- a/src/editor/nodeDefs/core/delay.js
+++ b/src/editor/nodeDefs/core/delay.js
@@ -177,9 +177,7 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          <p>Introduces a delay into a flow or rate limits messages.</p>
-        }
+        renderDescription: () => <p>Introduces a delay into a flow or rate limits messages.</p>
     });
 
 

--- a/src/editor/nodeDefs/core/espeak.js
+++ b/src/editor/nodeDefs/core/espeak.js
@@ -142,8 +142,6 @@ module.exports = function(RED) {
         </div>
       )
     },
-    renderDescription: function () {
-      return (<p>TTS node for serving output to speech</p>)
-    }
+    renderDescription: () => <p>TTS node for serving output to speech</p>
   });
 };

--- a/src/editor/nodeDefs/core/espeak.js
+++ b/src/editor/nodeDefs/core/espeak.js
@@ -141,6 +141,9 @@ module.exports = function(RED) {
           <p>Each message can also modify the playback <b>msg.pitch</b> and <b>msg.speed</b>.</p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (<p>TTS node for serving output to speech</p>)
     }
   });
 };

--- a/src/editor/nodeDefs/core/function.js
+++ b/src/editor/nodeDefs/core/function.js
@@ -182,6 +182,11 @@ module.exports = function(RED){
               </p>
             </div>
           )
+        },
+        renderDescription: function () {
+          return(
+            <p>Create functions for data with javascript</p>
+          )
         }
     });
 };

--- a/src/editor/nodeDefs/core/function.js
+++ b/src/editor/nodeDefs/core/function.js
@@ -183,10 +183,6 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          return(
-            <p>Create functions for data with javascript</p>
-          )
-        }
-    });
+        renderDescription: () => <p>Create functions for data with javascript</p>
+  });
 };

--- a/src/editor/nodeDefs/core/inject.js
+++ b/src/editor/nodeDefs/core/inject.js
@@ -519,10 +519,6 @@ render: function () {
         </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Inject the action of a node</p>
-      )
-    }
+    renderDescription: () => <p>Inject the action of a node</p>
   });
 };

--- a/src/editor/nodeDefs/core/inject.js
+++ b/src/editor/nodeDefs/core/inject.js
@@ -518,6 +518,11 @@ render: function () {
           </p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Inject the action of a node</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/core/notify.js
+++ b/src/editor/nodeDefs/core/notify.js
@@ -124,6 +124,11 @@ module.exports = function(RED){
           </p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Creates a browser notification</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/core/notify.js
+++ b/src/editor/nodeDefs/core/notify.js
@@ -125,10 +125,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Creates a browser notification</p>
-      )
-    }
+    renderDescription: () => <p>Creates a browser notification</p>
   });
 };

--- a/src/editor/nodeDefs/core/status.js
+++ b/src/editor/nodeDefs/core/status.js
@@ -269,6 +269,11 @@ module.exports = function(RED){
 
           </div>
       )
+    },
+    renderDescription: function () {
+      return(
+        <p>Send status messages from other nodes on the same tab.</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/core/status.js
+++ b/src/editor/nodeDefs/core/status.js
@@ -270,10 +270,6 @@ module.exports = function(RED){
           </div>
       )
     },
-    renderDescription: function () {
-      return(
-        <p>Send status messages from other nodes on the same tab.</p>
-      )
-    }
+    renderDescription: () => <p>Send status messages from other nodes on the same tab.</p>
   });
 };

--- a/src/editor/nodeDefs/core/template.js
+++ b/src/editor/nodeDefs/core/template.js
@@ -131,6 +131,13 @@ module.exports = function(RED){
               </div>
             </div>
           )
+        },
+        renderDescription: function () {
+          return (
+            <p>
+            Creates a new message based on the provided template.
+              </p>
+          )
         }
-    });
+  });
 };

--- a/src/editor/nodeDefs/core/template.js
+++ b/src/editor/nodeDefs/core/template.js
@@ -132,12 +132,6 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          return (
-            <p>
-            Creates a new message based on the provided template.
-              </p>
-          )
-        }
+        renderDescription: () => <p>Creates a new message based on the provided template.</p>
   });
 };

--- a/src/editor/nodeDefs/core/voicerec.js
+++ b/src/editor/nodeDefs/core/voicerec.js
@@ -42,10 +42,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      render (
-        <p>Creates a Speech Recognition Node that is always on</p>
-      )
-    }
+    renderDescription: () => <p>Creates a Speech Recognition Node that is always on</p>
   });
 }

--- a/src/editor/nodeDefs/core/voicerec.js
+++ b/src/editor/nodeDefs/core/voicerec.js
@@ -41,6 +41,11 @@ module.exports = function(RED){
         </p>
         </div>
       )
+    },
+    renderDescription: function () {
+      render (
+        <p>Creates a Speech Recognition Node that is always on</p>
+      )
     }
   });
 }

--- a/src/editor/nodeDefs/io/camera.js
+++ b/src/editor/nodeDefs/io/camera.js
@@ -42,6 +42,11 @@ module.exports = function(RED){
               <p>Attaches a base64 (dataURL) picture from your webcam to <code>msg.image</code>.</p>
             </div>
           )
+        },
+        renderDescription: function () {
+          return(
+            <p>Uses webcam to take a picture</p>
+          )
         }
       });
 };

--- a/src/editor/nodeDefs/io/camera.js
+++ b/src/editor/nodeDefs/io/camera.js
@@ -43,10 +43,6 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          return(
-            <p>Uses webcam to take a picture</p>
-          )
-        }
+        renderDescription: () => <p>Uses webcam to take a picture</p>
       });
 };

--- a/src/editor/nodeDefs/io/eventsource.js
+++ b/src/editor/nodeDefs/io/eventsource.js
@@ -78,6 +78,13 @@ module.exports = function(RED) {
           </p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return(
+        <p>
+          EventSource Input Node
+        </p>
+      )
     }
   });
 
@@ -130,12 +137,7 @@ module.exports = function(RED) {
         </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Delivers an Eventsource(es) stream</p>
-      )
-    }
-  });
-
+    renderDescription: () => <p>EventSource Output Node</p>
+   });
 })();
 }

--- a/src/editor/nodeDefs/io/eventsource.js
+++ b/src/editor/nodeDefs/io/eventsource.js
@@ -1,7 +1,6 @@
 module.exports = function(RED) {
   (function () {
 
-
   function sse_label() {
     return this.name || "[sse] " + (this.topic || "eventsource");
   }
@@ -129,6 +128,11 @@ module.exports = function(RED) {
         <div>
           <p>This configuration node connects an EventSource (Server Sent Events) client to the specified URL.</p>
         </div>
+      )
+    },
+    renderDescription: function () {
+      return (
+        <p>Delivers an Eventsource(es) stream</p>
       )
     }
   });

--- a/src/editor/nodeDefs/io/gamepad.js
+++ b/src/editor/nodeDefs/io/gamepad.js
@@ -71,6 +71,11 @@ module.exports = function(RED){
           </p>
         </div>
       )
+    },
+    renderHelp: function () {
+      return(
+        <p>Receives Data from USB Gamepads</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/io/gamepad.js
+++ b/src/editor/nodeDefs/io/gamepad.js
@@ -72,10 +72,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderHelp: function () {
-      return(
-        <p>Receives Data from USB Gamepads</p>
-      )
-    }
-  });
+    renderDescription: () => <p>Receives Data from USB Gamepads</p>
+   });
 };

--- a/src/editor/nodeDefs/io/geolocate.js
+++ b/src/editor/nodeDefs/io/geolocate.js
@@ -44,6 +44,11 @@ module.exports = function(RED){
               </p>
             </div>
           )
+        },
+        renderDescription: function () {
+          return (
+                  <p>Returns the geolocation of your current device</p>
+                 )
         }
-    });
+  });
 };

--- a/src/editor/nodeDefs/io/geolocate.js
+++ b/src/editor/nodeDefs/io/geolocate.js
@@ -45,10 +45,6 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          return (
-                  <p>Returns the geolocation of your current device</p>
-                 )
-        }
+        renderDescription: () => <p>Returns the geolocation of your current device</p>
   });
 };

--- a/src/editor/nodeDefs/io/gpio.js
+++ b/src/editor/nodeDefs/io/gpio.js
@@ -864,6 +864,11 @@ module.exports = function(RED){
               </ul>
           </div>
           )
+        },
+        renderDescription: function () {
+          return(
+            <p>Activate GPIO pins(Analog and Digital)</p>
+          )
         }
     });
 

--- a/src/editor/nodeDefs/io/gpio.js
+++ b/src/editor/nodeDefs/io/gpio.js
@@ -113,7 +113,8 @@ module.exports = function(RED){
           <p>gpio input node. A node for receiving data from General Purpose Input and Outputs (GPIOs) pins though the use of johnny-five I/O Plugins</p>
         </div>
       )
-    }
+    },
+    renderDescription: () => <p>GPIO Input Node</p>
   });
 
 
@@ -275,7 +276,8 @@ module.exports = function(RED){
           <p>gpio output node. A node for sending data to General Purpose Input and Outputs (GPIOs) pins though the use of johnny-five I/O Plugins</p>
         </div>
       )
-    }
+    },
+    renderDescription: () => <p>GPIO Output Node</p>
   });
 
 
@@ -865,12 +867,7 @@ module.exports = function(RED){
           </div>
           )
         },
-        renderDescription: function () {
-          return(
-            <p>Activate GPIO pins(Analog and Digital)</p>
-          )
-        }
+        renderDescription: () => <p>GPIO Output Node</p>
     });
-
 
 };

--- a/src/editor/nodeDefs/io/httpin.js
+++ b/src/editor/nodeDefs/io/httpin.js
@@ -159,11 +159,6 @@ module.exports = function (RED) {
           </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Makes http requests to CORS enabled servers</p>
-      )
-    }
-
+    renderDescription: () => <p>Makes http requests to CORS enabled servers</p>
   });
 };

--- a/src/editor/nodeDefs/io/httpin.js
+++ b/src/editor/nodeDefs/io/httpin.js
@@ -109,6 +109,9 @@ module.exports = function (RED) {
   <p>
     Provides a node for making http requests.
   </p>
+  <p>
+    <i>*All addresses must be https:// and have CORS enabled</i>
+  </p>
   <p>The URL and HTTP method can be configured in the node, if they are left blank they should be set in an incoming message on <code>msg.url</code> and <code>msg.method</code>:</p>
   <ul>
     <li>
@@ -154,7 +157,12 @@ module.exports = function (RED) {
               : If you need to configure a proxy please add <b>http_proxy=...</b> to your environment variables and restart Node-RED.
             </p>
           </div>
-             )
+      )
+    },
+    renderDescription: function () {
+      return (
+        <p>Makes http requests to CORS enabled servers</p>
+      )
     }
 
   });

--- a/src/editor/nodeDefs/io/meshblu.js
+++ b/src/editor/nodeDefs/io/meshblu.js
@@ -556,6 +556,11 @@ RED.nodes.registerType('meshblu-server',{
               </div>
       </div>
       );
+    },
+    renderDescription: function () {
+      return (
+        <p>Enable Octoblu meshblu server connection with a UUID</p>
+      )
     }
   });
 

--- a/src/editor/nodeDefs/io/meshblu.js
+++ b/src/editor/nodeDefs/io/meshblu.js
@@ -291,7 +291,8 @@ module.exports = function(RED){
       return (
         <p>meshblu input node. Connects to a server and either receives messages sent directly to the connected uuid or subscribes to broadcasts from a specified uuid.</p>
       )
-    }
+    },
+    renderDescription: () => <p>meshblue input node.</p>
   });
 
 
@@ -465,6 +466,11 @@ RED.nodes.registerType('meshblu out',{
           <p>Connects to a meshblu server and either broadcasts out the <b>msg</b> to any subscribers or sends the <b>msg</b> to a specific device.</p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Meshblu Out</p>
+      )
     }
   });
 
@@ -557,12 +563,7 @@ RED.nodes.registerType('meshblu-server',{
       </div>
       );
     },
-    renderDescription: function () {
-      return (
-        <p>Enable Octoblu meshblu server connection with a UUID</p>
-      )
-    }
+    renderDescription: () => <p>Meshblue output node</p>
   });
-
 
 };

--- a/src/editor/nodeDefs/io/socketio.js
+++ b/src/editor/nodeDefs/io/socketio.js
@@ -211,6 +211,11 @@ module.exports = function(RED){
               <p>This configuration node connects a WebSocket client to the specified URL.</p>
             </div>
           )
+        },
+        renderDescription: function () {
+          return(
+            <p>Connect to a WebSocket Server as a client</p>
+          )
         }
     });
 

--- a/src/editor/nodeDefs/io/socketio.js
+++ b/src/editor/nodeDefs/io/socketio.js
@@ -212,12 +212,8 @@ module.exports = function(RED){
             </div>
           )
         },
-        renderDescription: function () {
-          return(
-            <p>Connect to a WebSocket Server as a client</p>
-          )
-        }
-    });
+        renderDescription: () => <p>Connect to a WebSocket Server as a client</p>
+     });
 
 })();
 };

--- a/src/editor/nodeDefs/logic/change.js
+++ b/src/editor/nodeDefs/logic/change.js
@@ -1,6 +1,5 @@
 module.exports = function(RED){
-  RED.nodes.registerType('change', {
-    color: "#E2D96E",
+  RED.nodes.registerType('change', { color: "#E2D96E",
     category: 'function',
     defaults: {
       name: {value:""},
@@ -251,6 +250,11 @@ module.exports = function(RED){
         </ul>
 
         </div>
+      )
+    },
+    renderDescription: function () {
+      return (
+        <p>Set, change or delete properties of a message.</p>
       )
     }
   });

--- a/src/editor/nodeDefs/logic/change.js
+++ b/src/editor/nodeDefs/logic/change.js
@@ -252,10 +252,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Set, change or delete properties of a message.</p>
-      )
-    }
+    renderDescription: () => <p>Set, change or delete properties of a message.</p>
   });
 };

--- a/src/editor/nodeDefs/logic/range.js
+++ b/src/editor/nodeDefs/logic/range.js
@@ -68,10 +68,6 @@ module.exports = function(RED){
         </div>
       )
     },
-    renderDescription: function () {
-      return(
-        <p>A simple function node to remap numeric input values to another scale.</p>
-      )
-    }
+    renderDescription: () => <p>A simple function node to remap numeric input values to another scale.</p>
   });
 };

--- a/src/editor/nodeDefs/logic/range.js
+++ b/src/editor/nodeDefs/logic/range.js
@@ -67,6 +67,11 @@ module.exports = function(RED){
 
         </div>
       )
+    },
+    renderDescription: function () {
+      return(
+        <p>A simple function node to remap numeric input values to another scale.</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/logic/switch.js
+++ b/src/editor/nodeDefs/logic/switch.js
@@ -295,6 +295,11 @@ module.exports = function(RED){
         </p>
       </div>
       )
+    },
+    renderDescription: function () {
+      return(
+        <p>Route messages based off properties</p>
+      )
     }
   });
 };

--- a/src/editor/nodeDefs/logic/switch.js
+++ b/src/editor/nodeDefs/logic/switch.js
@@ -296,10 +296,6 @@ module.exports = function(RED){
       </div>
       )
     },
-    renderDescription: function () {
-      return(
-        <p>Route messages based off properties</p>
-      )
-    }
+    renderDescription: () => <p>Route messages based off properties</p>
   });
 };

--- a/src/editor/nodeDefs/parsers/json.js
+++ b/src/editor/nodeDefs/parsers/json.js
@@ -13,6 +13,11 @@ module.exports = function(RED){
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";
+        },
+        renderDescription: function () {
+          return(
+            <p>Parses JSON</p>
+          )
         }
     });
 };

--- a/src/editor/nodeDefs/parsers/json.js
+++ b/src/editor/nodeDefs/parsers/json.js
@@ -14,10 +14,6 @@ module.exports = function(RED){
         labelStyle: function() {
             return this.name?"node_label_italic":"";
         },
-        renderDescription: function () {
-          return(
-            <p>Parses JSON</p>
-          )
-        }
+        renderDescription: () => <p>Parses JSON</p>
     });
 };

--- a/src/editor/nodeDefs/storage/localdb.js
+++ b/src/editor/nodeDefs/storage/localdb.js
@@ -68,6 +68,11 @@ module.exports = function(RED) {
         <p><a href="https://mozilla.github.io/localForage">https://mozilla.github.io/localForage</a></p>
         </div>
       )
+    },
+    renderDescription: function () {
+      return (
+        <p>Writes data to local storage</p>
+      )
     }
   });
 
@@ -129,6 +134,11 @@ module.exports = function(RED) {
           <a href="https://mozilla.github.io/localForage">https://mozilla.github.io/localForage</a>
           </p>
           </div>
+      )
+    },
+    renderDescription: function () {
+      return (
+        <p>Reads data in localStorage</p>
       )
     }
   });

--- a/src/editor/nodeDefs/storage/localdb.js
+++ b/src/editor/nodeDefs/storage/localdb.js
@@ -136,10 +136,6 @@ module.exports = function(RED) {
           </div>
       )
     },
-    renderDescription: function () {
-      return (
-        <p>Reads data in localStorage</p>
-      )
-    }
+    renderDescription: () => <p>Reads data in localStorage</p>  
   });
 }

--- a/src/editor/ui/palette.js
+++ b/src/editor/ui/palette.js
@@ -107,8 +107,8 @@ RED.palette = (function() {
             }
             var helpContent = '';
             var node_def = RED.nodes.getType(type);
-            if(node_def && node_def.renderHelp){
-                helpContent = getHTML(node_def.renderHelp());
+            if(node_def && node_def.renderDescription){
+                helpContent = getHTML(node_def.renderDescription());
             }
 
             popOverContent = $(l+(info?info:helpContent||$("script[data-help-name|='"+type+"']").html()||"<p>"+RED._("palette.noInfo")+"</p>").trim())


### PR DESCRIPTION
Before, the standard procedure was to take the first <p> the renderHelp in the nodeDef and use that as the description for the node.  The issue was that when we moved to the JSX solution and the return portion of the build, this was broken.

I took out that need and replaced it with a renderDescription field in the nodeDef that allows you to customize the description of the node.

#46 should be resolved by this